### PR TITLE
[fix] Ensure we're using Streams2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var Readable = require('stream').Readable;
+var Readable = require('readable-stream').Readable;
 var StringDecoder = require('string_decoder').StringDecoder;
 var url = require('url');
 var util = require('util');

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "back": "~0.1.5",
     "debug": "~0.8.0",
-    "http-https": "~1.0.0"
+    "http-https": "~1.0.0",
+    "readable-stream": "1.0.x"
   },
   "devDependencies": {
     "tap": "~0.4.8"


### PR DESCRIPTION
This module has issues when operating as Streams3, likely with the
overloading of the `pause` and `resume`. Switching this module back to
Streams2 in the meantime.