### PR TITLE
Add support for query_params option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: node_js
 node_js:
   - "0.10"
   - "0.11"
+  - "4"
 services:
   - couchdb

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ fully customize your `_changes` request. They include the following:
   since: 0, // update sequence to start from, 'now' will start it from latest
   heartbeat: 30 * 1000, // how often we want couchdb to send us a heartbeat message
   style: 'main_only', // specifies how many revisions returned all_docs would return leaf revs
-  include_docs: false // whether or not we want to return the full document as a property
+  include_docs: false, // whether or not we want to return the full document as a property
+  query_params: {} // custom arbitrary params to send in request e.g. { hello: 'world' }
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ function ChangesStream (options) {
   // Allow couch heartbeat to be used but we can just manage that timeout
   this.heartbeat = options.heartbeat || 30 * 1000;
   this.style = options.style || 'main_only';
+  this.query_params = options.query_params || {};
 
   this.filterIds = Array.isArray(options.filter)
     ? options.filter
@@ -87,7 +88,7 @@ ChangesStream.prototype.preRequest = function () {
       acc[key] = this[key];
     }
     return acc;
-  }.bind(this), {});
+  }.bind(this), JDUP(this.query_params));
 
   // Remove filter from query parameters since we have confirmed it as
   // a function

--- a/test/mock.js
+++ b/test/mock.js
@@ -1,0 +1,19 @@
+var util = require('util');
+var ChangesStream = require('../');
+
+module.exports = createMockChangesStream;
+
+function createMockChangesStream (overrides) {
+
+  function MockChangesStream (opts) {
+    ChangesStream.call(this, opts);
+  }
+
+  util.inherits(MockChangesStream, ChangesStream);
+
+  Object.keys(overrides).forEach(function (methodName) {
+    MockChangesStream.prototype[methodName] = overrides[methodName];
+  });
+
+  return MockChangesStream;
+}


### PR DESCRIPTION
Similar to `follow`, allows passing custom arbitrary query params in the feed request.

Simple change with unit test added. Also added Node 4 to Travis testing. Feedback welcomed!