### PR TITLE
Support feeds with `timeout` set

### DIFF
--- a/index.js
+++ b/index.js
@@ -280,7 +280,9 @@ ChangesStream.prototype._onError = function (err) {
 // artificial error to let the user know what happened.
 //
 ChangesStream.prototype._onEnd = function () {
-  this._onError(new Error('CouchDB disconnected gracefully'));
+  var err = new Error('CouchDB disconnected gracefully');
+  err.code = 'ECOUCHDBDISCONNECTEDGRACEFULLY'
+  this._onError(err)
 };
 
 //

--- a/index.js
+++ b/index.js
@@ -367,7 +367,6 @@ ChangesStream.prototype.destroy = function () {
   this.cleanup();
   this._decoder.end();
   this._decoder = null;
-  this.removeAllListeners();
   this.push(null);
 };
 


### PR DESCRIPTION
Pass `timeout` directly to CouchDB, and rename the old `timeout` option to `requestTimeout` (`timeout` specifies how long CouchDB should wait for a change to show up before closing the continuous feed). Treat the `last_seq` change as an ultimate end of the stream.

Allow for disabling heartbeats (since they take priority over `timeout`).

My use case here: I would like to still use the niceties provided by `changes-stream` (reconnects, being a stream, etc.), but all I need is the current state of CouchDB.

Add an error code for the fake error emitted on `end`.

Partially related to #8 in that 71245f5 likely fixes it.