### PR TITLE
Add use_post option to force using a POST request

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ fully customize your `_changes` request. They include the following:
   heartbeat: 30 * 1000, // how often we want couchdb to send us a heartbeat message
   style: 'main_only', // specifies how many revisions returned all_docs would return leaf revs
   include_docs: false, // whether or not we want to return the full document as a property
-  query_params: {} // custom arbitrary params to send in request e.g. { hello: 'world' }
+  query_params: {}, // custom arbitrary params to send in request e.g. { hello: 'world' }
+  use_post: false // switch the default HTTP method to POST (cannot be used with a filter array)
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -123,12 +123,12 @@ ChangesStream.prototype.preRequest = function () {
 ChangesStream.prototype.request = function () {
   // Setup possible query string options
   this.preRequest();
-  var changes_url = url.resolve(this.db, '_changes'),
-      opts = url.parse(this.use_post
+  var changes_url = url.resolve(this.db, '_changes');
+  var opts = url.parse(this.use_post
         ? changes_url
         : url.resolve(changes_url, '?' + qs.stringify(this.query))
-      ),
-      payload;
+      );
+  var payload;
   //
   // Handle both cases of POST and GET
   //


### PR DESCRIPTION
At times we need to pass a _lot_ of information to our _changes filters, essentially in a manner similar to the `filter` array but matching against keys other than the default `_id`). Using the query string for large amounts of data is not recommended (and indeed could fail) and switching to `POST` is much preferable. This option makes this possible, while taking care not to conflict with the existing `filter` array behaviour of automatic switch to `POST`.