### PR TITLE
Fix performance of the _readData() method

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,20 +214,26 @@ ChangesStream.prototype._readData = function (data) {
   debug('data event fired from the underlying _changes response');
   this.attempt = null;
 
-  this._buffer += this._decoder.write(data);
+  var text = this._decoder.write(data);
+  var lines = text.split('\n')
 
-  var lines = this._buffer.split('\n');
-  this._buffer = lines.pop();
+  if (lines.length > 1) {
+    this._buffer += lines.shift()
+    lines.unshift(this._buffer)
+    this._buffer = lines.pop()
 
-  for (var i=0; i<lines.length; i++) {
-    var line = lines[i];
+    for (var i=0; i<lines.length; i++) {
+      var line = lines[i];
 
-    try { line = JSON.parse(line) }
-    catch (ex) { return; }
-    //
-    // Process each change
-    //
-    this._onChange(line);
+      try { line = JSON.parse(line) }
+      catch (ex) { return; }
+      //
+      // Process each change
+      //
+      this._onChange(line);
+    }
+  } else {
+    this._buffer += text
   }
 };
 


### PR DESCRIPTION
Previously the _readData() function would split the ever-growing
buffer resulting in verly long durations for large packuments.
By splitting the incoming text, every chunk is only ever split once.